### PR TITLE
Remove leading slash from url (1.11 backport)

### DIFF
--- a/builtin/forCategory.ts
+++ b/builtin/forCategory.ts
@@ -1,13 +1,14 @@
-import { removeStoreCodeFromRoute } from '@vue-storefront/core/lib/multistore'
+import { removeStoreCodeFromRoute, currentStoreView, localizedDispatcherRouteName } from '@vue-storefront/core/lib/multistore'
 import { Payload } from '../types/Payload'
 
 export const forCategory = async ({ dispatch }, { url }: Payload) => {
-  url = (removeStoreCodeFromRoute(url) as string)
+  const { storeCode, appendStoreCode } = currentStoreView()
+  url = (removeStoreCodeFromRoute(url.startsWith('/') ? url.slice(1) : url) as string)
   try {
     const category = await dispatch('category/single', { key: 'url_path', value: url }, { root: true })
     if (category !== null) {
       return {
-        name: 'category',
+        name: localizedDispatcherRouteName('category', storeCode, appendStoreCode),
         params: {
           slug: category.slug
         }

--- a/builtin/forProduct.ts
+++ b/builtin/forProduct.ts
@@ -1,17 +1,18 @@
 import SearchQuery from '@vue-storefront/core/lib/search/searchQuery'
-import { removeStoreCodeFromRoute } from '@vue-storefront/core/lib/multistore'
+import { removeStoreCodeFromRoute, currentStoreView, localizedDispatcherRouteName } from '@vue-storefront/core/lib/multistore'
 import { Payload } from '../types/Payload'
 
 export const forProduct = async ({ dispatch }, { url, params }: Payload) => {
-  url = (removeStoreCodeFromRoute(url) as string)
+  const { storeCode, appendStoreCode } = currentStoreView()
   const productQuery = new SearchQuery()
+  url = (removeStoreCodeFromRoute(url.startsWith('/') ? url.slice(1) : url) as string)
   const productSlug = url.split('/').reverse()[0]
   productQuery.applyFilter({key: 'url_path', value: {'eq': productSlug}})
   const products = await dispatch('product/list', { query: productQuery }, { root: true })
   if (products && products.items && products.items.length) {
     const product = products.items[0]
     return {
-      name: product.type_id + '-product',
+      name: localizedDispatcherRouteName(product.type_id + '-product', storeCode, appendStoreCode),
       params: {
         slug: product.slug,
         parentSku: product.sku,


### PR DESCRIPTION
`forCategory` and `forProduct` could not find any matches because corresponding code in 1.111 had introduced some code to remove any leading slash from `url`. This fixes that.