### PR TITLE
Make sure story response is an actual story and not just an empty placeholder

### DIFF
--- a/builtin/forStoryblok.ts
+++ b/builtin/forStoryblok.ts
@@ -3,7 +3,7 @@ import { Payload } from '../types/Payload'
 export const forStoryblok = async ({ dispatch }, { url: fullSlug }: Payload) => {
   fullSlug = fullSlug || 'home'
   const story = await dispatch(`storyblok/loadStory`, { fullSlug }, { root: true })
-  if (story) {
+  if (story && story.story !== false) {
     return {
       name: 'storyblok',
       params: {


### PR DESCRIPTION
The response `{ story: false }` stopped _page not found_ from functioning as expected with the former version of the `if` statement. This resulted in a status code `200` instead of `404` as well.